### PR TITLE
fix: setBrush not working in line drawing bug (fix #409, #418)

### DIFF
--- a/examples/example02-useApiDirect.html
+++ b/examples/example02-useApiDirect.html
@@ -61,8 +61,10 @@
                 <div class="sub-menu-container menu" id="draw-line-sub-menu">
                     <ul class="menu">
                         <li class="menu-item">
-                            <label><input type="radio" name="select-line-type" value="freeDrawing" checked="checked"> Free drawing</label>
-                            <label><input type="radio" name="select-line-type" value="lineDrawing"> Straight line</label>
+							<form id="line-type-form">
+								<label><input type="radio" name="select-line-type" value="freeDrawing" checked="checked"> Free drawing</label>
+								<label><input type="radio" name="select-line-type" value="lineDrawing"> Straight line</label>
+							</form>
                         </li>
                         <li class="menu-item">
                             <div id="tui-brush-color-picker">Brush color</div>

--- a/examples/js/service-basic.js
+++ b/examples/js/service-basic.js
@@ -503,6 +503,7 @@ $btnDrawLine.on('click', function() {
     $displayingSubMenu.hide();
     $displayingSubMenu = $drawLineSubMenu.show();
     $selectLine.eq(0).change();
+	$("#line-type-form").trigger("reset");
 });
 
 $selectLine.on('change', function() {

--- a/src/js/graphics.js
+++ b/src/js/graphics.js
@@ -630,8 +630,8 @@ class Graphics {
         const drawingMode = this._drawingMode;
         let compName = components.FREE_DRAWING;
 
-        if (drawingMode === drawingModes.LINE) {
-            compName = drawingModes.LINE;
+        if (drawingMode === drawingModes.LINE_DRAWING) {
+            compName = components.LINE;
         }
 
         this.getComponent(compName).setBrush(option);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [ ] It's submitted to right branch according to our branching model
- [ ] It's right issue type on title
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [ ] It does not introduce a breaking change or has description for the breaking change

### Description

1. setBrush method is not working in line drawing when using API and mobile methods as shown in examples
2. Fix mismatching of drawingMode and component name for line drawing in setBrush method in graphics.js that causes this issue
3. Add a html form tag in example02 for resetting the line type whenever DrawLine button is clicked

### Issues

fix #409 #418

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨